### PR TITLE
Support pause monitor

### DIFF
--- a/cronitor.go
+++ b/cronitor.go
@@ -122,6 +122,27 @@ func (c Cronitor) GetMonitor(key string) (*Monitor, error) {
 	return monitor, nil
 }
 
+func (c Cronitor) PauseMonitor(key string) error {
+	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/monitors/%s/pause", apiEndpoint, key), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.sendHttpRequest(request)
+	if err != nil {
+		return err
+	}
+
+	if resp != nil && resp.StatusCode != 200 {
+		return &StatusError{
+			StatusCode: resp.StatusCode,
+			message:    fmt.Sprintf("Failed to pause monitor: %s .", key),
+		}
+	}
+
+	return nil
+}
+
 func (c Cronitor) sendHttpRequest(request *http.Request) (*http.Response, error) {
 	if c.ApiKey == "" {
 		return nil, fmt.Errorf("API key cannot be empty")


### PR DESCRIPTION
When a monitor is in a paused state Cronitor will record and display all telemetry events, but will not dispatch alerts if a schedule or assertion violation is detected.
Ref: https://cronitor.io/docs/monitor-api